### PR TITLE
Gracefully exit in CLI when contract is `0x`

### DIFF
--- a/bin/sevm.mjs
+++ b/bin/sevm.mjs
@@ -133,12 +133,16 @@ function make(handler) {
     return async argv => {
         const pathOrAddress = /** @type {string} */ (argv['contract']);
         const bytecode = await getBytecode(pathOrAddress);
-        if (bytecode !== null) {
+        const name = pathOrAddress === '' ? '-' : pathOrAddress;
+        if (bytecode === null) {
+            console.error(warn(`Cannot find bytecode for contract ${info(name)}`));
+            process.exit(2);
+        } else if (bytecode.toLowerCase() === '0x') {
+            console.error(warn(`Bytecode for contract ${info(name)} is '0x', might have been self-destructed`));
+            process.exit(3);
+        } else {
             const contract = new Contract(bytecode).patchdb();
             handler(contract, argv);
-        } else {
-            console.info(warn(`Cannot find bytecode for ${info(pathOrAddress)}`));
-            process.exit(1);
         }
     };
 }

--- a/test/__snapshots__/bin.snap.md
+++ b/test/__snapshots__/bin.snap.md
@@ -142,3 +142,8 @@ url ipfs://QmQaEuFFsAwGbKd51LPcsLkKD5NwsB8aAzg7KkRsjuhjf2
    18  STOP   
 
 ```
+
+```err catch-error-when-exec-self-destructed-contract
+Bytecode for contract - is '0x', might have been self-destructed
+
+```

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -13,25 +13,25 @@ describe('::bin', function () {
     it('should exit with a zero code using `--help`', function () {
         const cli = chaiExec(sevm, ['--help']);
 
-        expect(cli).to.exit.with.code(0);
         expect(cli.stdout).to.matchSnapshot('out', this);
         expect(cli).stderr.to.be.empty;
+        expect(cli).to.exit.with.code(0);
     });
 
     it('should exit with non-zero code on unknown flag', function () {
         const cli = chaiExec(sevm, ['-h']);
 
-        expect(cli).to.exit.with.not.code(0);
         expect(cli).stdout.to.be.empty;
         expect(cli.stderr).to.matchSnapshot('err', this);
+        expect(cli).to.exit.with.not.code(0);
     });
 
     it('should exit with non-zero code on unknown command', function () {
         const cli = chaiExec(sevm, ['unknowncommand']);
 
-        expect(cli).to.exit.with.not.code(0);
         expect(cli).stdout.to.be.empty;
         expect(cli.stderr).to.matchSnapshot('err', this);
+        expect(cli).to.exit.with.not.code(0);
     });
 
     it('should display metadata from JSON `bytecode`', function () {
@@ -41,16 +41,24 @@ describe('::bin', function () {
         }`;
         const cli = chaiExec(sevm, ['metadata', '-', '--no-color'], { input });
 
-        expect(cli).to.exit.with.code(0);
         expect(cli.stdout).to.matchSnapshot('out', this);
         expect(cli).stderr.to.be.empty;
+        expect(cli).to.exit.with.code(0);
     });
 
     it('should run `dis` command and find non-reacheable chunk', function () {
         const cli = chaiExec(sevm, ['dis', '-', '--no-color'], { input: '0x6001600201600c56010203045b62fffefd5b00' });
 
-        expect(cli).to.exit.with.code(0);
         expect(cli.stdout).to.matchSnapshot('out', this);
         expect(cli).stderr.to.be.empty;
+        expect(cli).to.exit.with.code(0);
+    });
+
+    it('should catch error when exec self-destructed contract', function () {
+        const cli = chaiExec(sevm, ['metadata', '-', '--no-color'], { input: '0x' });
+
+        expect(cli.stdout).to.be.empty;
+        expect(cli).stderr.to.matchSnapshot('err', this);
+        expect(cli).to.exit.with.code(3);
     });
 });


### PR DESCRIPTION
Usually the empty contract comes when a contract has been self-destructed or when it does not have associated code.