### PR TITLE
Make bytecode hex string parser stricter

### DIFF
--- a/src/.bytes.ts
+++ b/src/.bytes.ts
@@ -18,7 +18,7 @@ export function arrayify(data: Uint8Array | ArrayLike<number> | string): Uint8Ar
     const buffer = new Uint8Array((data.length - start) / 2);
     for (let i = start, j = 0; i < data.length; i += 2, j++) {
         const byte = data.slice(i, i + 2);
-        const value = parseInt(byte, 16);
+        const value = Number('0x' + byte);
         if (value >= 0) {
             buffer[j] = value;
         } else {

--- a/test/__snapshots__/bin.snap.md
+++ b/test/__snapshots__/bin.snap.md
@@ -143,6 +143,11 @@ url ipfs://QmQaEuFFsAwGbKd51LPcsLkKD5NwsB8aAzg7KkRsjuhjf2
 
 ```
 
+```err catch-error-when-input-is-not-a-valid-hex-string
+Error: Unable to decode, invalid hex byte 'ax' found at position '7'
+
+```
+
 ```err log-debug-trace-when-NODE_DEBUG=sevm-is-set
 SEVM <pid>: ENOENT: no such file or directory, open <addr>
 SEVM <pid>: ENOENT: no such file or directory, open <addr>

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -54,6 +54,14 @@ describe('::bin', function () {
         expect(cli).to.exit.with.code(0);
     });
 
+    it('should catch error when input is not a valid hex string', function () {
+        const cli = chaiExec(sevm, ['dis', '-', '--no-color'], { input: '0x0011ax' });
+
+        expect(cli.stdout).to.be.empty;
+        expect(cli).stderr.to.matchSnapshot('err', this);
+        expect(cli).to.exit.with.code(1);
+    });
+
     it('should log debug trace when `NODE_DEBUG=sevm` is set', function () {
         /**
          * `FORCE_COLOR: 0` is set to remove colorized output coming from Node. 

--- a/test/step.test.ts
+++ b/test/step.test.ts
@@ -194,6 +194,9 @@ describe('::step', function () {
                 expect(() => step.decode(p + '010203xx').next()).to.throw(
                     `Unable to decode, invalid hex byte 'xx' found at position '${p.length + 7}'`
                 );
+                expect(() => step.decode(p + '010203ax').next()).to.throw(
+                    `Unable to decode, invalid hex byte 'ax' found at position '${p.length + 7}'`
+                );
             });
         }));
 


### PR DESCRIPTION
Fail parsing when an hex byte starts with a valid hex digit, _e.g._, `ax`.

Also it improves error handling in CLI when input is not valid.