### PR TITLE
Conditional expression serialization based on its size

### DIFF
--- a/src/ast/alu.ts
+++ b/src/ast/alu.ts
@@ -2,7 +2,7 @@ import { type Expr, Tag, Val, MOD_256 } from './index';
 
 abstract class Bin extends Tag {
     constructor(readonly left: Expr, readonly right: Expr) {
-        super();
+        super(Math.max(left.depth, right.depth) + 1, left.count + right.count + 1);
     }
 }
 
@@ -98,19 +98,19 @@ export class Exp extends Bin {
 
 abstract class Cmp extends Tag {
     constructor(readonly left: Expr, readonly right: Expr, readonly equal: boolean = false) {
-        super();
+        super(Math.max(left.depth, right.depth) + 1, left.count + right.count + 1);
     }
 }
 
 abstract class Unary extends Tag {
     constructor(readonly value: Expr) {
-        super();
+        super(value.depth + 1, value.count + 1);
     }
 }
 
 abstract class Shift extends Tag {
     constructor(readonly value: Expr, readonly shift: Expr) {
-        super();
+        super(Math.max(value.depth, shift.depth) + 1, value.count + shift.count + 1);
     }
 }
 
@@ -142,7 +142,7 @@ export class Eq extends Bin {
 export class IsZero extends Tag {
     readonly tag = 'IsZero';
     constructor(readonly value: Expr) {
-        super();
+        super(value.depth + 1, value.count + 1);
     }
     eval(): Expr {
         const val = this.value.eval();
@@ -206,7 +206,7 @@ export class Not extends Unary {
 export class Byte extends Tag {
     readonly tag = 'Byte';
     constructor(readonly pos: Expr, readonly data: Expr) {
-        super();
+        super(Math.max(pos.depth, data.depth) + 1, pos.count + data.count + 1);
     }
     eval(): Expr {
         const pos = this.pos.eval();

--- a/src/ast/flow.ts
+++ b/src/ast/flow.ts
@@ -68,7 +68,7 @@ export class JumpDest implements IInst {
 export class Sig extends Tag {
     readonly tag = 'Sig';
     constructor(readonly selector: string, readonly positive = true) {
-        super();
+        super(0, 1);
     }
     eval(): Expr {
         return this;

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -232,12 +232,16 @@ export class Local extends Tag {
 
     nrefs = 0;
 
+    #memo: Expr | undefined = undefined;
+
     constructor(readonly index: number, readonly value: Expr) {
         super();
     }
 
     override eval(): Expr {
-        return this.value.eval();
+        if (this.#memo === undefined)
+            this.#memo = this.value.eval();
+        return this.#memo;
     }
 
     override unwrap(): Expr {

--- a/src/ast/index.ts
+++ b/src/ast/index.ts
@@ -170,6 +170,8 @@ export abstract class Tag {
 
     type?: Type;
 
+    constructor(readonly depth: number, readonly count: number) { }
+
     isVal(): this is Val {
         return this.tag === 'Val';
     }
@@ -215,7 +217,7 @@ export class Val extends Tag {
 
     constructor(readonly val: bigint, readonly pushStateId?: number) {
         if (val < 0 || val >= MOD_256) throw new Error(`Val is a not a valid unsigned 256-word: ${val}`);
-        super();
+        super(0, 1);
     }
 
     override eval(): Expr {
@@ -235,7 +237,7 @@ export class Local extends Tag {
     #memo: Expr | undefined = undefined;
 
     constructor(readonly index: number, readonly value: Expr) {
-        super();
+        super(value.depth + 1, value.count + 1);
     }
 
     override eval(): Expr {

--- a/src/ast/memory.ts
+++ b/src/ast/memory.ts
@@ -3,7 +3,7 @@ import { Tag, type Expr, type IInst } from '.';
 export class MLoad extends Tag {
     readonly tag = 'MLoad';
     constructor(readonly location: Expr, readonly value?: Expr) {
-        super();
+        super(Math.max(location.depth, value?.depth ?? 0) + 1, location.count + (value?.count ?? 0) + 1);
     }
     eval(): Expr {
         return this.value ? this.value.eval() : new MLoad(this.location.eval());

--- a/src/ast/special.ts
+++ b/src/ast/special.ts
@@ -10,7 +10,7 @@ export class Prop extends Tag {
     readonly tag = 'Prop';
 
     constructor(readonly symbol: string, override readonly type: Type) {
-        super();
+        super(0, 1);
     }
 
     eval(): Expr {
@@ -69,7 +69,7 @@ export const FNS = {
 export class Fn extends Tag {
     readonly tag = 'Fn';
     constructor(readonly mnemonic: keyof typeof FNS, readonly value: Expr) {
-        super();
+        super(value.depth + 1, value.count + 1);
         this.type = FNS[mnemonic][1];
     }
 
@@ -87,7 +87,9 @@ export class DataCopy extends Tag {
         readonly address?: Expr,
         readonly bytecode?: Uint8Array,
     ) {
-        super();
+        super(
+            Math.max(offset.depth, size.depth, address?.depth ?? 0) + 1,
+            offset.count + size.count + (address?.count ?? 0) + 1);
     }
 
     eval(): this {
@@ -100,6 +102,9 @@ export class DataCopy extends Tag {
  */
 export class CallValue extends Tag {
     readonly tag = 'CallValue';
+    constructor() {
+        super(0, 1);
+    }
     eval(): Expr {
         return this;
     }
@@ -108,7 +113,7 @@ export class CallValue extends Tag {
 export class CallDataLoad extends Tag {
     readonly tag = 'CallDataLoad';
     constructor(public location: Expr) {
-        super();
+        super(location.depth + 1, location.count + 1);
     }
     eval(): Expr {
         return new CallDataLoad(this.location.eval());

--- a/src/ast/storage.ts
+++ b/src/ast/storage.ts
@@ -85,7 +85,10 @@ export class MappingLoad extends Tag {
         readonly items: Expr[],
         readonly structlocation?: bigint
     ) {
-        super();
+        super(
+            Math.max(slot.depth, ...items.map(e => e.depth)) + 1,
+            slot.count + items.reduce((accum, curr) => accum + curr.count, 0) + 1
+        );
         if (!(location in mappings)) {
             mappings[location] = {
                 name: undefined,
@@ -105,7 +108,7 @@ export class MappingLoad extends Tag {
 export class SLoad extends Tag {
     readonly tag = 'SLoad';
     constructor(readonly slot: Expr, readonly variable: Variable | undefined) {
-        super();
+        super(slot.depth + 1, slot.count + 1);
     }
     eval(): Expr {
         return new SLoad(this.slot.eval(), this.variable);

--- a/src/ast/system.ts
+++ b/src/ast/system.ts
@@ -1,9 +1,16 @@
 import { type IInst, Tag, type Expr, evalE } from '.';
 
+function info(...args: Expr[]): [depth: number, count: number] {
+    return [
+        Math.max(...args.map(e => e.depth)) + 1,
+        (args?.reduce((accum, curr) => accum + curr.count, 0) ?? 0) + 1
+    ];
+}
+
 export class Sha3 extends Tag {
     readonly tag = 'Sha3';
     constructor(readonly offset: Expr, readonly size: Expr, readonly args?: Expr[]) {
-        super();
+        super(...info(offset, size, ...args ?? []));
     }
 
     eval(): Sha3 {
@@ -33,7 +40,7 @@ export class Create extends Tag {
         readonly size: Expr,
         readonly bytecode: Uint8Array | null = null
     ) {
-        super();
+        super(...info(value, offset, size));
     }
 
     eval(): Expr {
@@ -54,7 +61,7 @@ export class Call extends Tag {
         readonly retStart: Expr,
         readonly retLen: Expr
     ) {
-        super();
+        super(...info(gas, address, value, argsStart, argsLen, retStart, retLen));
     }
 
     eval(): Expr {
@@ -68,7 +75,7 @@ export class ReturnData extends Tag {
     readonly wrapped = false;
 
     constructor(readonly retOffset: Expr, readonly retSize: Expr) {
-        super();
+        super(...info(retOffset, retSize));
     }
 
     eval(): Expr {
@@ -87,7 +94,7 @@ export class CallCode extends Tag {
         readonly outputStart: Expr,
         readonly outputLength: Expr
     ) {
-        super();
+        super(...info(gas, address, value, memoryStart, memoryLength, outputStart, outputLength));
     }
 
     eval(): Expr {
@@ -98,7 +105,7 @@ export class CallCode extends Tag {
 export class Create2 extends Tag {
     readonly tag = 'Create2';
     constructor(readonly offset: Expr, readonly size: Expr, readonly value: Expr) {
-        super();
+        super(...info(offset, size, value));
     }
 
     eval(): Expr {
@@ -116,7 +123,7 @@ export class StaticCall extends Tag {
         readonly outputStart: Expr,
         readonly outputLength: Expr
     ) {
-        super();
+        super(...info(gas, address, memoryStart, memoryLength, outputStart, outputLength));
     }
 
     eval(): Expr {
@@ -134,7 +141,7 @@ export class DelegateCall extends Tag {
         readonly outputStart: Expr,
         readonly outputLength: Expr
     ) {
-        super();
+        super(...info(gas, address, memoryStart, memoryLength, outputStart, outputLength));
     }
 
     eval(): Expr {

--- a/src/sol.ts
+++ b/src/sol.ts
@@ -58,7 +58,11 @@ function solExpr(expr: Expr): string {
         case 'Val':
             return `${expr.isJumpDest() ? '[J]' : ''}0x${expr.val.toString(16)}`;
         case 'Local':
-            return expr.nrefs > 0 ? `local${expr.index}` : sol`${expr.value}`;
+            return expr.nrefs > 0
+                ? `local${expr.index}`
+                : expr.count >= 1000
+                    ? `/*expression too big to decompile: ${expr.count} AST nodes*/local${expr.index}`
+                    : sol`${expr.value}`;
         case 'Add':
         case 'Mul':
         case 'Sub':

--- a/test/__snapshots__/examples.snap.md
+++ b/test/__snapshots__/examples.snap.md
@@ -708,7 +708,13 @@ Metadata {
 ```
 
 ```out Simple-Hook.mjs
-top Prop { symbol: 'tx.gasprice', type: 'uint', tag: 'Prop' }
+top Prop {
+  depth: 0,
+  count: 1,
+  symbol: 'tx.gasprice',
+  type: 'uint',
+  tag: 'Prop'
+}
 
 ```
 


### PR DESCRIPTION
This PR introduces `depth` and `count`, referring to the depth and count of AST nodes in expression d9c366997af76624b916b63324e5a1bb4fb423fa.

This allows Solidity serialization to decide whether or not to serialize an expression based on its size or depth. When the size is too big `>1000` nodes, the serialization bails. This is to avoid OOM errors. This kind of issue can arise in the following contract https://etherscan.io/address/0xaeef3c744e07b4ceeb7469460f220c697b8fb8bc#code

```solidity
library ModexpInverse {
    function run(uint256 t2) internal pure returns (uint256 t0) {
        // solium-disable-next-line security/no-inline-assembly
        assembly {
            let n := 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47
            t0 := mulmod(t2, t2, n)
            let t5 := mulmod(t0, t2, n)
            let t1 := mulmod(t5, t0, n)
            let t3 := mulmod(t5, t5, n)
            let t8 := mulmod(t1, t0, n)
            let t4 := mulmod(t3, t5, n)
            let t6 := mulmod(t3, t1, n)
            t0 := mulmod(t3, t3, n)
            let t7 := mulmod(t8, t3, n)
            t3 := mulmod(t4, t3, n)
            t0 := mulmod(t0, t0, n)
            t0 := mulmod(t0, t0, n)
            t0 := mulmod(t0, t0, n)
            t0 := mulmod(t0, t0, n)
            t0 := mulmod(t0, t0, n)
            // [...many more mulmod]
        }
    }
}
```

where each `mulmod(t0, t0, n)` duplicates the size of expression when serialized. Note that when it is not serialized, there is no issue since internally object references are stored.

Moreover, this PR memoizes `eval` for `Local` expression bd54ba64976f081efbf4d003c022d29a244bc8f7
This avoids re-evaluating the same expression multiple times. This happens when this `Local` is used in multiple places.
