### PR TITLE
Include `--patch/--no-patch` option in `sevm` CLI to let the user choose when to patch contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,10 @@ Commands:
 
 Options:
   --version  Show version number                                       [boolean]
-  --color    Display with colors, use `--no-color` to deactivate colors
+  --color    Displays with colors, use `--no-color` to deactivate colors
+                                                       [boolean] [default: true]
+  --patch    Patches the Contract public functions and events with signatures fr
+             om https://openchain.xyz/, use `--no-patch` to skip patching
                                                        [boolean] [default: true]
   --help     Show help                                                 [boolean]
 
@@ -320,7 +323,10 @@ Positionals:
 
 Options:
   --version     Show version number                                    [boolean]
-  --color       Display with colors, use `--no-color` to deactivate colors
+  --color       Displays with colors, use `--no-color` to deactivate colors
+                                                       [boolean] [default: true]
+  --patch       Patches the Contract public functions and events with signatures
+                 from https://openchain.xyz/, use `--no-patch` to skip patching
                                                        [boolean] [default: true]
   --help        Show help                                              [boolean]
   --with-stack  Include the current stack next to each decoded opcode

--- a/test/__snapshots__/bin.snap.md
+++ b/test/__snapshots__/bin.snap.md
@@ -16,7 +16,10 @@ Commands:
 
 Options:
   --version  Show version number                                       [boolean]
-  --color    Display with colors, use `--no-color` to deactivate colors
+  --color    Displays with colors, use `--no-color` to deactivate colors
+                                                       [boolean] [default: true]
+  --patch    Patches the Contract public functions and events with signatures fr
+             om https://openchain.xyz/, use `--no-patch` to skip patching
                                                        [boolean] [default: true]
   --help     Show help                                                 [boolean]
 
@@ -53,7 +56,10 @@ Commands:
 
 Options:
   --version  Show version number                                       [boolean]
-  --color    Display with colors, use `--no-color` to deactivate colors
+  --color    Displays with colors, use `--no-color` to deactivate colors
+                                                       [boolean] [default: true]
+  --patch    Patches the Contract public functions and events with signatures fr
+             om https://openchain.xyz/, use `--no-patch` to skip patching
                                                        [boolean] [default: true]
   --help     Show help                                                 [boolean]
 
@@ -92,7 +98,10 @@ Commands:
 
 Options:
   --version  Show version number                                       [boolean]
-  --color    Display with colors, use `--no-color` to deactivate colors
+  --color    Displays with colors, use `--no-color` to deactivate colors
+                                                       [boolean] [default: true]
+  --patch    Patches the Contract public functions and events with signatures fr
+             om https://openchain.xyz/, use `--no-patch` to skip patching
                                                        [boolean] [default: true]
   --help     Show help                                                 [boolean]
 

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -39,7 +39,7 @@ describe('::bin', function () {
             "bytecode": "60806040525f80fdfea2646970667358221220213295e11660e0fa1851b6245c99f6d8ef0d1ad319b69a6483694b3a316c2dc564736f6c63430008150033",
             "abi": []
         }`;
-        const cli = chaiExec(sevm, ['metadata', '-', '--no-color'], { input });
+        const cli = chaiExec(sevm, ['metadata', '-', '--no-color', '--no-patch'], { input });
 
         expect(cli.stdout).to.matchSnapshot('out', this);
         expect(cli).stderr.to.be.empty;
@@ -47,7 +47,7 @@ describe('::bin', function () {
     });
 
     it('should run `dis` command and find non-reacheable chunk', function () {
-        const cli = chaiExec(sevm, ['dis', '-', '--no-color'], { input: '0x6001600201600c56010203045b62fffefd5b00' });
+        const cli = chaiExec(sevm, ['dis', '-', '--no-color', '--no-patch'], { input: '0x6001600201600c56010203045b62fffefd5b00' });
 
         expect(cli.stdout).to.matchSnapshot('out', this);
         expect(cli).stderr.to.be.empty;


### PR DESCRIPTION
Given CLI now depends on a network connection to fetch signatures,
positive `bin` tests use the `--no-patch` to avoid depending on a network connection.