### PR TITLE
Replace `ethers` CLI dependency with custom provider and `js-sha3`

### DIFF
--- a/bin/.address.mjs
+++ b/bin/.address.mjs
@@ -1,0 +1,23 @@
+import js_sha3 from 'js-sha3';
+
+/**
+ * @param {string} address 
+ * @returns {boolean}
+ */
+export function isValidAddress(address) {
+    if (typeof (address) !== 'string') throw new Error('Invalid address, it must be a string');
+    if (address.startsWith('0x')) address = address.slice(2);
+    if (!address.match(/^[0-9a-fA-F]{40}$/)) throw new Error('Invalid address, not an Ethereum address');
+    if (!address.match(/([A-F].*[a-f])|([a-f].*[A-F])/)) return true;
+
+    const address_ = address.toLowerCase()
+    const keccakHash = js_sha3.keccak256(address_);
+
+    for (let i = 0; i < address_.length; i++) {
+        let output = parseInt(keccakHash[i], 16) >= 8
+            ? address_[i].toUpperCase()
+            : address_[i]
+        if (address[i] !== output) return false
+    }
+    return true
+}

--- a/bin/.address.mjs
+++ b/bin/.address.mjs
@@ -1,6 +1,10 @@
 import js_sha3 from 'js-sha3';
 
 /**
+ * Implementation based on:
+ * - https://github.com/miguelmota/ethereum-checksum-address/blob/master/index.js
+ * - https://github.com/ethers-io/ethers.js/blob/main/lib.esm/address/address.js
+ * 
  * @param {string} address 
  * @returns {boolean}
  */

--- a/bin/.provider.mjs
+++ b/bin/.provider.mjs
@@ -1,0 +1,103 @@
+
+/**
+ * @typedef {number|'earliest'|'latest'|'safe'|'finalized'|'pending'} BlockTag
+ */
+
+/**
+ * Simple JSON-RPC provider.
+ */
+export class Provider {
+
+    constructor(url = 'http://127.0.0.1:8545') {
+        this.url = url;
+        this._id = 1;
+    }
+
+    /**
+     * Returns the current block number.
+     * 
+     * See also https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_blocknumber.
+     * 
+     * @returns {Promise<number>} The current block number.
+     */
+    async blockNumber() {
+        return parseInt(await this.post('eth_blockNumber', []), 16);
+    }
+
+    /**
+     * Returns the current chain id.
+     * 
+     * See also https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_chainId
+     * 
+     * @returns {Promise<number>}
+     */
+    async chainId() {
+        return parseInt(await this.post('eth_chainId', []), 16);
+    }
+
+    /**
+     * Returns the receipts of a given block.
+     * 
+     * @param {number} blockNumber 
+     * @returns {Promise<{transactionHash: string, contractAddress?: string}[]>}
+     */
+    getBlockReceipts(blockNumber) {
+        return this.post('eth_getBlockReceipts', [blockNumber]);
+    }
+
+    /**
+     * Returns the code at a given account address and block number.
+     * 
+     * See also https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getcode.
+     * 
+     * @param {string} address 20-byte account address.
+     * @param {BlockTag} blockNumber The block number or tag at which to make the request.
+     * See also https://ethereum.org/en/developers/docs/apis/json-rpc/#default-block.
+     * @returns {Promise<string>}
+     */
+    getCode(address, blockNumber = 'latest') {
+        return this.post('eth_getCode', [address, blockNumber]);
+    }
+
+    /**
+     * Returns the current client version.
+     * 
+     * See also https://ethereum.org/en/developers/docs/apis/json-rpc/#web3_clientversion.
+     * 
+     * @returns {Promise<string>} 
+     */
+    async clientVersion() {
+        return await this.post('web3_clientVersion', []);
+    }
+
+    /**
+     * Sends a JSON-RPC `POST` request to the provider.
+     * 
+     * @template T
+     * @param {'eth_blockNumber'|'eth_chainId'|'eth_getBlockReceipts'|'eth_getCode'|'web3_clientVersion'} method 
+     * @param {unknown[]} params 
+     * @returns {Promise<T>} The `result` of the request.
+     */
+    async post(method, params) {
+        /** @typedef {{jsonrpc: string, id: number, error: unknown, result: unknown}} JsonRpcResponse */
+
+        const id = this._id++;
+        const resp = await fetch(this.url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+                jsonrpc: '2.0',
+                method,
+                params,
+                id,
+            }),
+        });
+
+        const json = /** @type {JsonRpcResponse} */(await resp.json());
+        if (resp.status === 200 && json.jsonrpc === '2.0' && json.id === id && json.error === undefined)
+            return /** @type {T} */ (json.result);
+        throw new Error(`Invalid JSON-RPC response: ${JSON.stringify(json)}`);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
         "ansi-colors": "^4.1.3",
         "cbor-js": "^0.1.0",
         "env-paths": "^3.0.0",
-        "ethers": "^6.9.0",
+        "js-sha3": "^0.9.3",
         "yargs": "^17.7.2"
     },
     "devDependencies": {
@@ -77,6 +77,7 @@
         "eslint": "^8.51.0",
         "eslint-plugin-chai-expect": "^3.0.0",
         "eslint-plugin-mocha": "^10.1.0",
+        "ethers": "^6.9.0",
         "mocha": "^10.0.1",
         "solc": "^0.8.21",
         "typedoc": "^0.25.2",

--- a/scripts/4bytedb.mjs
+++ b/scripts/4bytedb.mjs
@@ -4,8 +4,9 @@
 import c from 'ansi-colors';
 import { expect } from 'chai';
 import { createHash } from 'crypto';
-import { EventFragment, FunctionFragment, keccak256, toUtf8Bytes } from 'ethers';
+import { EventFragment, FunctionFragment } from 'ethers';
 import { readFileSync, writeFileSync } from 'fs';
+import js_sha3 from 'js-sha3';
 
 /** @typedef {{ [hash: string]: string }} Hashes */
 
@@ -66,7 +67,7 @@ function writeJson(fileName, hashes) {
  */
 const reduce = (entries, replacer) =>
     entries.reduce((/** @type {Hashes}*/ map, /** @type {string}*/ entry) => {
-        map[replacer(keccak256(toUtf8Bytes(entry)))] = entry;
+        map[replacer(js_sha3.keccak256(entry))] = entry;
         return map;
     }, {});
 
@@ -80,7 +81,7 @@ function main() {
         }
         expect(functions.length).to.be.equal(s.size);
     }, functions => {
-        const functionHashes = reduce(functions, s => s.substring(2, 10));
+        const functionHashes = reduce(functions, s => s.substring(0, 8));
         writeJson('functionHashes', functionHashes);
     });
 
@@ -93,7 +94,7 @@ function main() {
         }
         expect(events.length).to.be.equal(s.size);
     }, events => {
-        const eventHashes = reduce(events, s => s.substring(2));
+        const eventHashes = reduce(events, s => s);
         writeJson('eventHashes', eventHashes);
     });
 }

--- a/test/__snapshots__/bin.snap.md
+++ b/test/__snapshots__/bin.snap.md
@@ -160,7 +160,7 @@ Error: Unable to decode, invalid hex byte 'ax' found at position '7'
 ```err log-debug-trace-when-NODE_DEBUG=sevm-is-set
 SEVM <pid>: ENOENT: no such file or directory, open <addr>
 SEVM <pid>: ENOENT: no such file or directory, open <addr>
-SEVM <pid>: bad address checksum (argument="address", value="0x8Ba1f109551bD432803012645Ac136ddd64DBa72", code=INVALID_ARGUMENT, version=6.9.0)
+SEVM <pid>: Invalid address, bad address checksum
 Cannot find bytecode for contract 0x8Ba1f109551bD432803012645Ac136ddd64DBa72
 
 ```

--- a/test/bin.test.ts
+++ b/test/bin.test.ts
@@ -72,7 +72,7 @@ describe('::bin', function () {
             'NODE_DEBUG': 'sevm',
             'FORCE_COLOR': '0',
         };
-        // address doesn't checksum, this is to avoid ethers making a request,
+        // address doesn't checksum, this is to avoid CLI making a request,
         // thus making the test more robust
         const cli = chaiExec(sevm, ['metadata', '0x8Ba1f109551bD432803012645Ac136ddd64DBa72'], { env });
 

--- a/test/ercs.test.ts
+++ b/test/ercs.test.ts
@@ -1,4 +1,4 @@
-import { keccak_256 } from '@noble/hashes/sha3';
+import { keccak256 } from 'js-sha3';
 import { expect } from 'chai';
 
 import { Contract } from 'sevm';
@@ -9,7 +9,7 @@ describe('::ercs', function () {
     describe('erc165', function () {
         it('check `keccak_256` hash selector for `supportsInterface(bytes4)`', function () {
             const sig = 'supportsInterface(bytes4)';
-            const hash = Buffer.from(keccak_256(sig).slice(0, 4)).toString('hex');
+            const hash = keccak256(sig).slice(0, 8);
             expect(hash).to.be.equal('01ffc9a7');
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,6 +1435,11 @@ js-sha3@0.8.0:
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
+js-sha3@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.9.3.tgz#f0209432b23a66a0f6c7af592c26802291a75c2a"
+  integrity sha512-BcJPCQeLg6WjEx3FE591wVAevlli8lxsxm9/FzV4HXkV49TmBH38Yvrpce6fjbADGMKFrBMGTqrVz3qPIZ88Gg==
+
 js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"


### PR DESCRIPTION
This PR removes `ethers` as a CLI dependency, leave it only as a dev dependency.

To do so, it replaces `EtherscanProvider` with a custom JSON-RPC provider using `https://cloudflare-eth.com/` RPC.
And includes a custom implementation of checksum addresses using `js-sha3` (used to compute `keccak256` hash).

Internally, we also replace `ethers` `keccak256` usages for `js-sha3`.
