### PR TITLE
Separate `selector` from rest `args` in `Revert`

### DIFF
--- a/src/ast/system.ts
+++ b/src/ast/system.ts
@@ -177,6 +177,11 @@ export class Revert implements IInst {
     readonly name = 'Revert';
 
     /**
+     * https://docs.soliditylang.org/en/latest/control-structures.html#panic-via-assert-and-error-via-require
+     */
+    static readonly ERROR = '08c379a0';
+
+    /**
      * Stop the current context execution, revert the state changes (see `STATICCALL` for a list
      * of state changing opcodes) and return the unused gas to the caller.
      *
@@ -189,10 +194,14 @@ export class Revert implements IInst {
      * @param size byte size to copy (size of the return data).
      * @param args
      */
-    constructor(readonly offset: Expr, readonly size: Expr, readonly args?: Expr[]) { }
+    constructor(readonly offset: Expr, readonly size: Expr, readonly selector?: string, readonly args?: Expr[]) { }
 
     eval() {
-        return new Revert(this.offset.eval(), this.size.eval(), this.args?.map(evalE));
+        return new Revert(this.offset.eval(), this.size.eval(), this.selector, this.args?.map(evalE));
+    }
+
+    isRequire(): boolean {
+        return this.selector === undefined || this.selector === Revert.ERROR;
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,7 +161,8 @@ export function isRevertBlock(falseBlock: Stmt[]): falseBlock is [...Inst[], Rev
     return (
         falseBlock.length >= 1 &&
         falseBlock.slice(0, -1).every(stmt => stmt.name === 'Local' || stmt.name === 'MStore') &&
-        falseBlock.at(-1)!.name === 'Revert'
+        falseBlock.at(-1)!.name === 'Revert' &&
+        (falseBlock.at(-1) as Revert).isRequire()
     );
 }
 

--- a/src/yul.ts
+++ b/src/yul.ts
@@ -1,6 +1,6 @@
 import { Contract } from '.';
 import type { Expr, Inst, MappingLoad, MappingStore, Stmt } from './ast';
-import { FNS, Tag, isExpr, isInst } from './ast';
+import { FNS, Revert, Tag, Val, isExpr, isInst } from './ast';
 
 /**
  * Returns the Yul `string` representation of `nodes` that are either
@@ -147,8 +147,10 @@ function yulStmt(stmt: Stmt): string {
             return yul`(${stmt.condition})`;
         case 'CallSite':
             return yul`$${stmt.selector}();`;
-        case 'Require':
-            return `require(${[stmt.condition, ...stmt.args].map(yulExpr).join(', ')})`;
+        case 'Require': {
+            const args = stmt.args.length === 0 ? [] : [new Val(BigInt('0x' + Revert.ERROR)), ...stmt.args];
+            return `require(${[stmt.condition, ...args].map(yulExpr).join(', ')})`;
+        }
         default:
             return yulInst(stmt);
     }

--- a/test/__snapshots__/contracts/control/modifier.snap.md
+++ b/test/__snapshots__/contracts/control/modifier.snap.md
@@ -82,7 +82,7 @@ object "runtime" {
             let local2 := 0x4 // #refs 3
             let local3 := sub(calldatasize(), local2) // #refs 0
             require(iszero(lt(local3, 0x20)))
-            require(eq(and(0xffffffffffffffffffffffffffffffffffffffff, and(0xffffffffffffffffffffffffffffffffffffffff, div(sload(0x1), exp(0x100, 0x0)))), and(0xffffffffffffffffffffffffffffffffffffffff, caller())), 0x8c379a000000000000000000000000000000000000000000000000000000000, 0x20, 0x20, 0x4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572)
+            require(eq(and(0xffffffffffffffffffffffffffffffffffffffff, and(0xffffffffffffffffffffffffffffffffffffffff, div(sload(0x1), exp(0x100, 0x0)))), and(0xffffffffffffffffffffffffffffffffffffffff, caller())), 0x8c379a0, 0x20, 0x20, 0x4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572)
             let local4 := calldataload(local2) // #refs 0
             let local5 := add(local4, 0x3) // #refs 0
             sstore(0x0, local5)
@@ -382,7 +382,7 @@ object "runtime" {
             let local3 := sub(calldatasize(), local2) // #refs 0
             require(iszero(lt(local3, 0x20)))
             let local4 := sub(shl(0x1, 0xa0), 0x1) // #refs 0
-            require(eq(and(caller(), local4), and(local4, sload(0x1))), 0x8c379a000000000000000000000000000000000000000000000000000000000, 0x20, 0x20, 0x4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572)
+            require(eq(and(caller(), local4), and(local4, sload(0x1))), 0x8c379a0, 0x20, 0x20, 0x4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572)
             sstore(0x0, add(0x3, calldataload(local2)))
             stop()
         }

--- a/test/__snapshots__/contracts/control/require.snap.md
+++ b/test/__snapshots__/contracts/control/require.snap.md
@@ -60,8 +60,8 @@ object "runtime" {
             require(iszero(lt(local3, 0x20)))
             let local4 := calldataload(local2) // #refs 3
             let local5 := caller() // #refs 1
-            require(iszero(eq(and(0xffffffffffffffffffffffffffffffffffffffff, local5), and(0xffffffffffffffffffffffffffffffffffffffff, 0x0))), 0x8c379a000000000000000000000000000000000000000000000000000000000, 0x20, 0x7, 0x617070726f766500000000000000000000000000000000000000000000000000)
-            require(gt(local4, 0x0), 0x8c379a000000000000000000000000000000000000000000000000000000000, 0x20, 0xf, 0x617070726f766520616464726573730000000000000000000000000000000000)
+            require(iszero(eq(and(0xffffffffffffffffffffffffffffffffffffffff, local5), and(0xffffffffffffffffffffffffffffffffffffffff, 0x0))), 0x8c379a0, 0x20, 0x7, 0x617070726f766500000000000000000000000000000000000000000000000000)
+            require(gt(local4, 0x0), 0x8c379a0, 0x20, 0xf, 0x617070726f766520616464726573730000000000000000000000000000000000)
             let local6 := 0x0 // #refs -1
             mstore(local6/*=0x0*/, and(0xffffffffffffffffffffffffffffffffffffffff, and(0xffffffffffffffffffffffffffffffffffffffff, local5)))
             let local7 := add(0x20, local6) // #refs -1
@@ -316,8 +316,8 @@ object "runtime" {
             require(iszero(lt(local3, 0x20)))
             let local4 := calldataload(local2) // #refs 1
             let local5 := caller() // #refs 0
-            require(and(local5, sub(shl(0x1, 0xa0), 0x1)), 0x8c379a000000000000000000000000000000000000000000000000000000000, 0x20, 0x7, 0x617070726f766500000000000000000000000000000000000000000000000000)
-            require(gt(local4, 0x0), 0x8c379a000000000000000000000000000000000000000000000000000000000, 0x20, 0xf, 0x617070726f766520616464726573730000000000000000000000000000000000)
+            require(and(local5, sub(shl(0x1, 0xa0), 0x1)), 0x8c379a0, 0x20, 0x7, 0x617070726f766500000000000000000000000000000000000000000000000000)
+            require(gt(local4, 0x0), 0x8c379a0, 0x20, 0xf, 0x617070726f766520616464726573730000000000000000000000000000000000)
             let local6 := 0x0 // #refs -1
             mstore(local6/*=0x0*/, and(local5, sub(shl(0x1, 0xa0), 0x1)))
             mstore(0x20, local6)

--- a/test/__snapshots__/mainnet/VotingEscrowDelegationProxy.sol
+++ b/test/__snapshots__/mainnet/VotingEscrowDelegationProxy.sol
@@ -60,7 +60,7 @@ contract Contract {
     }
 
     function 61893921() public payable {
-        require(msg.sender == var_2, memory[0x15c], 0x20, 0xd, 0x4163636573732064656e69656400000000000000000000000000000000000000);
+        require(msg.sender == var_2, "Access denied");
         var_2 = var_4;
         var_3 = var_5;
         log(0xe8d7597c306457cd1fa4eb0e165a1a4c3aea9808e274ea97c6b5d9f73a3c477f, var_4, var_5);
@@ -166,7 +166,7 @@ contract Contract {
     function e3a8d3ab() public payable {
         if ((_arg0 >>> 0xa0) == 0) {
             if ((_arg1 >>> 0xa0) == 0) {
-                require(msg.sender == var_2, memory[0x15c], 0x20, 0xd, 0x4163636573732064656e69656400000000000000000000000000000000000000);
+                require(msg.sender == var_2, "Access denied");
                 var_4 = _arg0;
                 var_5 = _arg1;
                 log(0x8f5425b30e6270c1011973f0ccf6d7795cc10623631523e4c45d2837d337d574, _arg0, _arg1);

--- a/test/forversion.test.ts
+++ b/test/forversion.test.ts
@@ -51,11 +51,11 @@ describe(`::forversion`, function () {
             expect(block.states).to.be.of.length(1);
             const state = block.states[0]!;
             expect(state.last?.eval())
-                .to.be.deep.equal(new Revert(new Val(0n), new Val(0n), []));
+                .to.be.deep.equal(new Revert(new Val(0n), new Val(0n), undefined, []));
 
             expect(contract.main.length).to.be.at.least(1);
             expect(contract.main.at(-1)?.eval()).to.be.deep.equal(
-                new Revert(new Val(0n), new Val(0n), [])
+                new Revert(new Val(0n), new Val(0n), undefined, [])
             );
         });
 


### PR DESCRIPTION
Moreover, include support to detect revert selector in Vyper.