### PR TITLE
Embed `cbor-js` decoder to avoid including its encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A Symbolic [Ethereum Virtual Machine (EVM)](https://medium.com/mycrypto/the-ethe
 
 > :construction: Under heavy development. Feel free to open an [issue](https://github.com/acuarica/evm/issues) if something is not right. :construction:
 
-- **Lightweight with virtually no dependencies, ~60kb minified**
+- **Lightweight with no dependencies, ~65 kB minified ~17 kB minified & brotlied**
 - [**Embedded functions and events signature database**](#evm-bytecode-function-and-event-signature-hashes) <small style="background: #f000b8; padding: 0.2em; border-radius: 3px">optional</small>
 - **Convert bytecode to opcodes**
 - **Extract events or functions information from bytecode**

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     ],
     "dependencies": {
         "ansi-colors": "^4.1.3",
-        "cbor-js": "^0.1.0",
         "env-paths": "^3.0.0",
         "js-sha3": "^0.9.3",
         "yargs": "^17.7.2"

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -65,37 +65,38 @@ export function splitMetadataHash(buffer: Parameters<typeof arrayify>[0]): {
     const data = new Uint8Array(bytecode.subarray(bytecode.length - 2 - dataLen, bytecode.length - 2));
     if (data.length !== dataLen) return { bytecode, metadata: undefined };
 
+    let obj;
     try {
-        const obj = cbor(data.buffer);
-        if (obj === null || typeof obj !== 'object') return { bytecode, metadata: undefined };
-
-        const metadata = new Metadata();
-
-        if ('ipfs' in obj && obj['ipfs'] instanceof Uint8Array) {
-            metadata.protocol = 'ipfs';
-            metadata.hash = bs58(obj['ipfs']);
-            delete obj['ipfs'];
-        } else if ('bzzr0' in obj && obj['bzzr0'] instanceof Uint8Array) {
-            metadata.protocol = 'bzzr0';
-            metadata.hash = hexlify(obj['bzzr0']);
-            delete obj['bzzr0'];
-        } else if ('bzzr1' in obj && obj['bzzr1'] instanceof Uint8Array) {
-            metadata.protocol = 'bzzr1';
-            metadata.hash = hexlify(obj['bzzr1']);
-            delete obj['bzzr1'];
-        }
-        if ('solc' in obj && obj['solc'] instanceof Uint8Array) {
-            metadata.solc = obj['solc'].join('.');
-            delete obj['solc'];
-        }
-
-        return {
-            bytecode: bytecode.subarray(0, bytecode.length - 2 - dataLen),
-            metadata: Object.assign(metadata, obj)
-        };
+        obj = cbor(data.buffer);
     } catch {
         return { bytecode, metadata: undefined };
     }
+    if (obj === null || typeof obj !== 'object') return { bytecode, metadata: undefined };
+
+    const metadata = new Metadata();
+
+    if ('ipfs' in obj && obj['ipfs'] instanceof Uint8Array) {
+        metadata.protocol = 'ipfs';
+        metadata.hash = bs58(obj['ipfs']);
+        delete obj['ipfs'];
+    } else if ('bzzr0' in obj && obj['bzzr0'] instanceof Uint8Array) {
+        metadata.protocol = 'bzzr0';
+        metadata.hash = hexlify(obj['bzzr0']);
+        delete obj['bzzr0'];
+    } else if ('bzzr1' in obj && obj['bzzr1'] instanceof Uint8Array) {
+        metadata.protocol = 'bzzr1';
+        metadata.hash = hexlify(obj['bzzr1']);
+        delete obj['bzzr1'];
+    }
+    if ('solc' in obj && obj['solc'] instanceof Uint8Array) {
+        metadata.solc = obj['solc'].join('.');
+        delete obj['solc'];
+    }
+
+    return {
+        bytecode: bytecode.subarray(0, bytecode.length - 2 - dataLen),
+        metadata: Object.assign(metadata, obj)
+    };
 }
 
 /**
@@ -144,7 +145,6 @@ function bs58(buffer: Uint8Array): string {
     }
 
     result.reverse();
-
     return String.fromCharCode(...result);
 }
 
@@ -324,22 +324,17 @@ function cbor(data: ArrayBufferLike): CBORItem {
                 return decodeItem();
             case 7:
                 switch (length) {
-                    case 20:
-                        return false;
-                    case 21:
-                        return true;
-                    case 22:
-                        return null;
-                    case 23:
-                        return undefined;
-                    default:
-                        return undefined;
+                    case 20: return false;
+                    case 21: return true;
+                    case 22: return null;
+                    case 23: return undefined;
+                    default: return undefined;
                 }
             default: throw new Error('Unrecognized major type');
         }
     }
 
     const item = decodeItem();
-    if (offset !== data.byteLength) throw "Remaining bytes";
+    if (offset !== data.byteLength) throw 'Remaining bytes';
     return item;
 }

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,4 +1,3 @@
-import CBOR from 'cbor-js';
 import { arrayify, hexlify } from './.bytes';
 
 /**
@@ -67,7 +66,9 @@ export function splitMetadataHash(buffer: Parameters<typeof arrayify>[0]): {
     if (data.length !== dataLen) return { bytecode, metadata: undefined };
 
     try {
-        const obj = CBOR.decode(data.buffer);
+        const obj = cbor(data.buffer);
+        if (obj === null || typeof obj !== 'object') return { bytecode, metadata: undefined };
+
         const metadata = new Metadata();
 
         if ('ipfs' in obj && obj['ipfs'] instanceof Uint8Array) {
@@ -98,6 +99,8 @@ export function splitMetadataHash(buffer: Parameters<typeof arrayify>[0]): {
 }
 
 /**
+ * **Implementation from https://github.com/pur3miish/base58-js**
+ * 
  * Converts a Uint8Array into a base58 string.
  *
  * @param buffer Unsigned integer array to encode.
@@ -143,4 +146,200 @@ function bs58(buffer: Uint8Array): string {
     result.reverse();
 
     return String.fromCharCode(...result);
+}
+
+/**
+ * 
+ */
+type CBORItem = number | boolean | Uint8Array | string | null | undefined | CBORItem[] | { [key: string]: CBORItem };
+
+/**
+ * **Implementation from https://github.com/paroga/cbor-js**
+ * 
+ * Embedded it here to avoid including the encoder.
+ */
+function cbor(data: ArrayBufferLike): CBORItem {
+    const POW_2_24 = Math.pow(2, -24), POW_2_32 = Math.pow(2, 32);
+
+    const dataView = new DataView(data);
+    let offset = 0;
+
+    function read<T>(value: T, length: number) {
+        offset += length;
+        return value;
+    }
+    function readArrayBuffer(length: number) {
+        return read(new Uint8Array(data, offset, length), length);
+    }
+    function readFloat16() {
+        const tempArrayBuffer = new ArrayBuffer(4);
+        const tempDataView = new DataView(tempArrayBuffer);
+        const value = readUint16();
+
+        const sign = value & 0x8000;
+        let exponent = value & 0x7c00;
+        const fraction = value & 0x03ff;
+
+        if (exponent === 0x7c00)
+            exponent = 0xff << 10;
+        else if (exponent !== 0)
+            exponent += (127 - 15) << 10;
+        else if (fraction !== 0)
+            return fraction * POW_2_24;
+
+        tempDataView.setUint32(0, sign << 16 | exponent << 13 | fraction << 13);
+        return tempDataView.getFloat32(0);
+    }
+    const readFloat32 = () => read(dataView.getFloat32(offset), 4);
+    const readFloat64 = () => read(dataView.getFloat64(offset), 8);
+    const readUint8 = () => read(dataView.getUint8(offset), 1);
+    const readUint16 = () => read(dataView.getUint16(offset), 2);
+    const readUint32 = () => read(dataView.getUint32(offset), 4);
+    const readUint64 = () => readUint32() * POW_2_32 + readUint32();
+    function readBreak() {
+        if (dataView.getUint8(offset) !== 0xff)
+            return false;
+        offset += 1;
+        return true;
+    }
+    function readLength(additionalInformation: number) {
+        if (additionalInformation < 24) return additionalInformation;
+        if (additionalInformation === 24) return readUint8();
+        if (additionalInformation === 25) return readUint16();
+        if (additionalInformation === 26) return readUint32();
+        if (additionalInformation === 27) return readUint64();
+        if (additionalInformation === 31) return -1;
+        throw "Invalid length encoding";
+    }
+    function readIndefiniteStringLength(majorType: number) {
+        const initialByte = readUint8();
+        if (initialByte === 0xff)
+            return -1;
+        const length = readLength(initialByte & 0x1f);
+        if (length < 0 || (initialByte >> 5) !== majorType)
+            throw "Invalid indefinite length element";
+        return length;
+    }
+
+    function appendUtf16data(utf16data: number[], length: number) {
+        for (let i = 0; i < length; ++i) {
+            let value = readUint8();
+            if (value & 0x80) {
+                if (value < 0xe0) {
+                    value = (value & 0x1f) << 6
+                        | (readUint8() & 0x3f);
+                    length -= 1;
+                } else if (value < 0xf0) {
+                    value = (value & 0x0f) << 12
+                        | (readUint8() & 0x3f) << 6
+                        | (readUint8() & 0x3f);
+                    length -= 2;
+                } else {
+                    value = (value & 0x0f) << 18
+                        | (readUint8() & 0x3f) << 12
+                        | (readUint8() & 0x3f) << 6
+                        | (readUint8() & 0x3f);
+                    length -= 3;
+                }
+            }
+
+            if (value < 0x10000) {
+                utf16data.push(value);
+            } else {
+                value -= 0x10000;
+                utf16data.push(0xd800 | (value >> 10));
+                utf16data.push(0xdc00 | (value & 0x3ff));
+            }
+        }
+    }
+
+    function decodeItem(): CBORItem {
+        const initialByte = readUint8();
+        const majorType = initialByte >> 5;
+        const additionalInformation = initialByte & 0x1f;
+        let i;
+        let length;
+
+        if (majorType === 7) {
+            switch (additionalInformation) {
+                case 25: return readFloat16();
+                case 26: return readFloat32();
+                case 27: return readFloat64();
+            }
+        }
+
+        length = readLength(additionalInformation);
+        if (length < 0 && (majorType < 2 || 6 < majorType)) throw "Invalid length";
+
+        switch (majorType) {
+            case 0:
+                return length;
+            case 1:
+                return -1 - length;
+            case 2:
+                if (length < 0) {
+                    const elements = [];
+                    let fullArrayLength = 0;
+                    while ((length = readIndefiniteStringLength(majorType)) >= 0) {
+                        fullArrayLength += length;
+                        elements.push(readArrayBuffer(length));
+                    }
+                    const fullArray = new Uint8Array(fullArrayLength);
+                    let fullArrayOffset = 0;
+                    for (i = 0; i < elements.length; ++i) {
+                        fullArray.set(elements[i], fullArrayOffset);
+                        fullArrayOffset += elements[i].length;
+                    }
+                    return fullArray;
+                }
+                return readArrayBuffer(length);
+            case 3:
+                const utf16data: number[] = [];
+                if (length < 0) {
+                    while ((length = readIndefiniteStringLength(majorType)) >= 0)
+                        appendUtf16data(utf16data, length);
+                } else
+                    appendUtf16data(utf16data, length);
+                return String.fromCharCode.apply(null, utf16data);
+            case 4:
+                let retArray: CBORItem[];
+                if (length < 0) {
+                    retArray = [];
+                    while (!readBreak())
+                        retArray.push(decodeItem());
+                } else {
+                    retArray = new Array(length) as CBORItem[];
+                    for (i = 0; i < length; ++i)
+                        retArray[i] = decodeItem();
+                }
+                return retArray;
+            case 5:
+                const retObject: Record<string, CBORItem> = {};
+                for (i = 0; i < length || length < 0 && !readBreak(); ++i) {
+                    const key = decodeItem() as string;
+                    retObject[key] = decodeItem();
+                }
+                return retObject;
+            case 6:
+                return decodeItem();
+            case 7:
+                switch (length) {
+                    case 20:
+                        return false;
+                    case 21:
+                        return true;
+                    case 22:
+                        return null;
+                    case 23:
+                        return undefined;
+                    default:
+                        return undefined;
+                }
+            default: throw new Error('Unrecognized major type');
+        }
+    }
+
+    const item = decodeItem();
+    if (offset !== data.byteLength) throw "Remaining bytes";
+    return item;
 }

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -17,6 +17,18 @@ describe('::metadata', function () {
         expect(metadata).to.be.undefined;
     });
 
+    it('should return original bytecode when metadata is not an object', function () {
+        const { bytecode, metadata } = splitMetadataHash('0x001904D20003');
+        expect(bytecode).to.be.deep.equal(new Uint8Array([0, 0x19, 0x04, 0xD2, 0x00, 0x03]));
+        expect(metadata).to.be.undefined;
+    });
+
+    it('should split metadata when it is an array', function () {
+        const { bytecode, metadata } = splitMetadataHash('0x0084010203040005');
+        expect(bytecode).to.be.deep.equal(new Uint8Array([0]));
+        expect(metadata).to.be.deep.equal({ '0': 1, '1': 2, '2': 3, '3': 4, protocol: '', hash: '', solc: '' });
+    });
+
     it('should decode when `solc` property is found', function () {
         const { metadata } = splitMetadataHash(compile('contract Test {}', '0.8.21', this, {
             metadata: {

--- a/types/cbor-js.d.ts
+++ b/types/cbor-js.d.ts
@@ -1,6 +1,0 @@
-
-declare module 'cbor-js' {
-
-    export function decode(data: ArrayBufferLike): Record<string, unknown>;
-
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -698,11 +698,6 @@ caniuse-lite@^1.0.30001370:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001375.tgz#8e73bc3d1a4c800beb39f3163bf0190d7e5d7672"
   integrity sha512-kWIMkNzLYxSvnjy0hL8w1NOaWNr2rn39RTAVyIwcw8juu60bZDWiF1/loOYANzjtJmy6qPgNmn38ro5Pygagdw==
 
-cbor-js@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/cbor-js/-/cbor-js-0.1.0.tgz#c80ce6120f387e8faa74370dfda21d965b8fc7f9"
-  integrity sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw==
-
 chai@^4.3.10:
   version "4.3.10"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.10.tgz#d784cec635e3b7e2ffb66446a63b4e33bd390384"


### PR DESCRIPTION
`cbor-js` includes both a decoder and encoder. However, we need only the decoder. This PR embeds the `cbor-js` decoder to avoid including the encoder. This provide a little gain in bundle size.

Additionally, this PR

- Removes `cbor-js` vendor types bbe838d859abceb754d6d9b6e23796930e48df4a
- Removes `cbor-js` dependency 13d96d1149a3bf6b418fb459c4738119e359fb7a
- Adds tests for when CBOR metadata is not an object, _e.g._, a number or an array 24534a4691730944b5c7d1d017b37330e861233d