### PR TITLE
Improve `4byte`'s `patch` method documentation

### DIFF
--- a/4byte/index.d.ts
+++ b/4byte/index.d.ts
@@ -10,14 +10,35 @@ type Lookup = { function: Hashes, event: Hashes };
 declare module 'sevm' {
     interface Contract {
         /**
-         * It looks up in the signature and events remote API for matching hashes.
+         * Looks up for matching `function` and `event` selectors in the `api.openchain.xyz` remote API.
+         * The endpoint used to fetch signatures is [https://api.openchain.xyz/signature-database/v1/lookup](https://docs.openchain.xyz/#/default/get_signature_database_v1_lookup).
+         * Please note that the global [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch) is used to make the request.
          *
          * When a matching `function` or `event` is found,
-         * it patches the `function` or `event` with the corresponding signature.
+         * it patches the `Contract`'s `function` or `event` with the corresponding signature.
          * 
-         * https://docs.openchain.xyz/#/default/get_signature_database_v1_lookup
+         * The `lookup` argument is an input/output argument to cache the result of the lookup.
+         * When no argument is provided (default) or empty object, it always performs the request to the remote API (no caching).
+         * In addition, it will populate the `lookup` argument with the result signatures of the request.
+         * In turn, this `lookup` result signatures can be provided to the next invocation to `patch` (for the same contract) to avoid making a request to the remote API.
+         * Thus, when catching the `lookup`, make sure to always pass a reference instead of a value.
          * 
-         * @param lookup 
+         * In the following example, whenever the `abiPath` file exists,
+         * the contract will be patched using the respective `lookup` signatures and avoid making the request to the remote API.
+         * On the other hand, when it does not exist, it will make the request to fetch `function` and `event` signatures.
+         * 
+         * ```ts
+         * const abiPath = "path/to/save/contract/abi";
+         * let lookup;
+         * if (fs.existsSync(abiPath)) {
+         *     lookup = JSON.parse(fs.readFileSync(abiPath, 'utf8'));
+         * } else {
+         *     lookup = {};
+         * }
+         * contract = await contract.patch(lookup);
+         * ```
+         * 
+         * @param lookup optional input/output lookup signatures provided by a previous invocation to `patch`.
          */
         patch(lookup: Partial<Lookup> = {}): Promise<this>;
     }

--- a/4byte/index.js
+++ b/4byte/index.js
@@ -3,16 +3,6 @@
 
 const sevm = require('sevm');
 
-/** @typedef {{ [hash: string]: {name: string, filtered: boolean}[] | null }} HashesResponse */
-
-/**
- * @param {HashesResponse} hashes 
- * @returns {{ [hash: string]: string[] }}
- */
-const mapHashes = hashes => Object.fromEntries(
-    Object.entries(hashes).map(([hash, matches]) => [hash, matches?.map(({ name }) => name) ?? []])
-);
-
 sevm.Contract.prototype.patch = async function (/** @type {Partial<import('.').Lookup>} */lookup = {}) {
     const keys = Object.keys;
     /** @type {(selector: string) => string} */
@@ -28,7 +18,17 @@ sevm.Contract.prototype.patch = async function (/** @type {Partial<import('.').L
             throw new Error(`Failed to fetch signatures from api.openchain.xyz, url: ${url}`);
         }
 
+        /** @typedef {{ [hash: string]: {name: string, filtered: boolean}[] | null }} HashesResponse */
         const { result } = /** @type {{result: { function: HashesResponse, event: HashesResponse }}} */ (await resp.json());
+
+        /**
+         * @param {HashesResponse} hashes 
+         * @returns {{ [hash: string]: string[] }}
+         */
+        const mapHashes = hashes => Object.fromEntries(
+            Object.entries(hashes).map(([hash, matches]) => [hash, matches?.map(({ name }) => name) ?? []])
+        );
+
         lookup.function = mapHashes(result.function);
         lookup.event = mapHashes(result.event);
     }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
         "solc": "^0.8.21",
         "typedoc": "^0.25.2",
         "typedoc-plugin-extras": "^3.0.0",
+        "typedoc-plugin-missing-exports": "^2.3.0",
         "typescript": "^5.2.2",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0"

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,7 +1,7 @@
 {
     "searchInComments": true,
     "includeVersion": true,
-    "plugin": ["typedoc-plugin-extras"],
+    "plugin": ["typedoc-plugin-extras", "typedoc-plugin-missing-exports"],
     "navigationLinks": {
         "GitHub": "http://github.com/acuarica/evm"
     },
@@ -10,5 +10,8 @@
     "footerTypedocVersion": true,
     "footerLastModified": true,
     "customTitle": "EVM Bytecode Analyzer & Decompiler",
-    "customDescription": "A Symbolic Ethereum Virtual Machine (EVM) interpreter and decompiler, along with several other utils for programmatically extracting information from bytecode"
+    "customDescription": "A Symbolic Ethereum Virtual Machine (EVM) interpreter and decompiler, along with several other utils for programmatically extracting information from bytecode",
+
+    // https://www.npmjs.com/package/typedoc-plugin-missing-exports
+    "placeInternalsInOwningModule": true,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2172,6 +2172,11 @@ typedoc-plugin-extras@^3.0.0:
   resolved "https://registry.yarnpkg.com/typedoc-plugin-extras/-/typedoc-plugin-extras-3.0.0.tgz#e41eeb815aaa572beb8c274834a6b7f51dd55b24"
   integrity sha512-eiAe3qtm2WbV5owdncpt0zHZPqsNZH2mzNGILPd4zqrvEZie3Et9es4cpGZ+8lHO/SI0pVKwsAj7IuMxPNOdYg==
 
+typedoc-plugin-missing-exports@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-2.3.0.tgz#ae0858bf383a08345cc09a99d428234cf6b85ecf"
+  integrity sha512-iI9ITNNLlbsLCBBeYDyu0Qqp3GN/9AGyWNKg8bctRXuZEPT7G1L+0+MNWG9MsHcf/BFmNbXL0nQ8mC/tXRicog==
+
 typedoc@^0.25.2:
   version "0.25.2"
   resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.2.tgz#39f525c28b6eb61da54dda4ec6b1500df620bed8"


### PR DESCRIPTION
In addition, this PR includes `typedoc-plugin-missing-exports` to avoid exposing `4byte` internal types.