### PR TITLE
Fix `Shl`'s `eval` arithmetic when result is larger than `2^256`

### DIFF
--- a/src/ast/alu.ts
+++ b/src/ast/alu.ts
@@ -217,6 +217,15 @@ export class Byte extends Tag {
     }
 }
 
+/**
+ * Left shift operation. https://www.evm.codes/#1b
+ * 
+ * `eval` definition
+ * 
+ * ```txt
+ * µ'_s[0] ≡ (µ_s[1] × 2^µ_s[0]) mod 2^256
+ * ```
+ */
 export class Shl extends Shift {
     readonly tag = 'Shl';
     eval(): Expr {

--- a/src/ast/alu.ts
+++ b/src/ast/alu.ts
@@ -222,7 +222,9 @@ export class Shl extends Shift {
     eval(): Expr {
         const val = this.value.eval();
         const shift = this.shift.eval();
-        return val.isVal() && shift.isVal() ? new Val(val.val << shift.val) : new Shl(val, shift);
+        return val.isVal() && shift.isVal()
+            ? new Val(mod256(val.val << shift.val))
+            : new Shl(val, shift);
     }
 }
 

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -6,6 +6,20 @@ import { cfg } from './utils/cfg';
 import { compile } from './utils/solc';
 
 describe('::contracts', function () {
+
+    it('should `Yul`ify bytecode with `SHL` 256-bits overflow arithmetic', function () {
+        // https://github.com/acuarica/evm/issues/125#issuecomment-2190710451
+        const contract = new Contract('0x60016101111b5ffd');
+        expect(contract.yul()).to.be.equal(`object "runtime" {
+    code {
+        revert(0x0, shl(0x1, 0x111))
+
+    }
+}
+`);
+        expect(contract.errors).to.be.deep.equal([]);
+    });
+
     const _ = (title: string, src: string) => ({ title, src });
 
     Object.entries<{ title: string, src: string }[]>({

--- a/test/exprs.test.ts
+++ b/test/exprs.test.ts
@@ -85,6 +85,8 @@ const $exprs = {
 
         t([2n, 3n, 'DIV', 1n, 'BYTE'], new Byte(new Val(1n), new Div(new Val(3n), new Val(2n))), new Val(0n), '(0x3 / 0x2 >> 0x1) & 1', 'byte(0x1, div(0x3, 0x2))'),
         t([2n, 3n, 'DIV', 2n, 'SHL'], new Shl(new Div(new Val(3n), new Val(2n)), new Val(2n)), new Val(4n), '0x3 / 0x2 << 0x2', 'shl(div(0x3, 0x2), 0x2)'),
+
+        t([0x1n, 0x111n, 'SHL'], new Shl(new Val(0x1n), new Val(0x111n)), new Val(0x0n), '0x1 << 0x111', 'shl(0x1, 0x111)'),
     ],
     special: [
         t(['BASEFEE'], Props['block.basefee'], id, 'block.basefee', 'basefee()'),


### PR DESCRIPTION
This PR fixes the `eval` implementation of `Shl`  which does not honor the Ethereum spec[1]. When the result of the `Shl` is larger than the word size, the error `Val is a not a valid unsigned 256-word` is raised. The `Shl` `eval` should use `mod 2^256` when result is larger than the word size.

<img width="363" alt="image" src="https://github.com/acuarica/evm/assets/4592980/f81a5d16-e499-4d36-b06f-f2ec8cc609d1">

Related to https://github.com/acuarica/evm/issues/125.

---

[1] https://ethereum.github.io/yellowpaper/paper.pdf