### PR TITLE
Introduce `Memory` class to represent context memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ const testContract = new Contract(bytecode, new class extends Shanghai {
                 super.CODECOPY(state, _opcode, evm);
 
                 if (dest?.isVal()) {
-                    const m = state.memory[Number(dest.val)] as DataCopy;
+                    const m = state.memory.get(dest.val) as DataCopy;
                     tokenContract = new Contract(m.bytecode!);
                 }
             };

--- a/bin/sevm.mjs
+++ b/bin/sevm.mjs
@@ -399,7 +399,8 @@ function cfg(contract) {
         label += '\\l';
         // label += inspect(state.memory);
         // label += '\\l';
-        Object.entries(state.memory).forEach(([k, v]) => (label += sol`${k}: ${v}\\l`));
+        for (const [k, v] of state.memory.entries())
+            label += sol`${k}: ${v}\\l`;
         label += state.stmts.map(stmt => sol`${stmt}`).join('\\l');
         label += '\\l';
 

--- a/examples/Advanced-Hooks.ts
+++ b/examples/Advanced-Hooks.ts
@@ -30,7 +30,7 @@ const testContract = new Contract(bytecode, new class extends Shanghai {
                 super.CODECOPY(state, _opcode, evm);
 
                 if (dest?.isVal()) {
-                    const m = state.memory[Number(dest.val)] as DataCopy;
+                    const m = state.memory.get(dest.val) as DataCopy;
                     tokenContract = new Contract(m.bytecode!);
                 }
             };

--- a/src/state.ts
+++ b/src/state.ts
@@ -99,18 +99,39 @@ export class Memory<in out E> {
     private constructor(private readonly _map: Map<bigint, E>) {
     }
 
+    /**
+     * Creates a new `Memory` with no set locations.
+     * 
+     * @returns an empty `Memory`.
+     */
     static new<E>(): Memory<E> {
         return new Memory<E>(new Map());
     }
 
+    /**
+     * @returns `boolean` indicating whether a value in the specified `location` exists or not.
+     */
     has(location: bigint): boolean {
         return this._map.has(location);
     }
 
+    /**
+     * Returns a specified value from the `Memory` object.
+     * If the value stored at the provided `location` is an `object`,
+     * then you will get a reference to that `object` and any change made to that `object` will effectively modify it inside the `Memory`.
+     * 
+     * @returns Returns the value stored at the specified `location`. If no value is stored at the specified `location`, `undefined` is returned.
+     */
     get(location: bigint): E | undefined {
         return this._map.get(location);
     }
 
+    /**
+     * Sets the new `value` at the specified `location`.
+     * If a value at the same `location` already exists, the value will be updated.
+     * 
+     * @returns the `this` `Memory` so calls can be chained.
+     */
     set(location: bigint, value: E): this {
         this._map.set(location, value);
         return this;
@@ -125,14 +146,23 @@ export class Memory<in out E> {
         return new Memory(new Map(this._map));
     }
 
+    /**
+     * @returns the number of values stored in the `Memory`.
+     */
     get size(): number {
         return this._map.size;
     }
 
+    /**
+     * Returns an iterable of keys in the `Memory`.
+     */
     keys(): IterableIterator<bigint> {
         return this._map.keys();
     }
 
+    /**
+     * Returns an iterable of location, value pairs for every entry in the `Memory`.
+     */
     entries(): IterableIterator<[bigint, E]> {
         return this._map.entries();
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -166,6 +166,21 @@ export class Memory<in out E> {
     entries(): IterableIterator<[bigint, E]> {
         return this._map.entries();
     }
+
+    /**
+     * 
+     * @param offset 
+     * @param size 
+     * @param miss 
+     * @returns 
+     */
+    range(offset: bigint, size: bigint, miss: (location: bigint) => E) {
+        const args = [];
+        for (let i = offset; i < offset + size; i += 32n) {
+            args.push(this.get(i) ?? miss(i));
+        }
+        return args;
+    }
 }
 
 /**

--- a/src/state.ts
+++ b/src/state.ts
@@ -100,7 +100,7 @@ export class Memory<in out E> {
     }
 
     static new<E>(): Memory<E> {
-        return new Memory(new Map());
+        return new Memory<E>(new Map());
     }
 
     has(location: bigint): boolean {

--- a/src/step.ts
+++ b/src/step.ts
@@ -730,11 +730,7 @@ const FrontierStep = {
 
             stmts.push(new ast.Log(event, offset_, size_, topics, function (offset, size) {
                 if (offset.isVal() && size.isVal() && size.val <= MAXSIZE) {
-                    const args = [];
-                    for (let i = offset.val; i < offset.val + size.val; i += 32n) {
-                        args.push(memory.get(i) ?? new ast.MLoad(new Val((i))));
-                    }
-                    return args;
+                    return memory.range(offset.val, size.val, i => new ast.MLoad(new Val(i)))
                 } else {
                     if (size.isVal() && size.val > MAXSIZE) {
                         throw new ExecError(`Memory size too large creating Log: ${size.val} in \`${size_.yul()}\``);

--- a/src/step.ts
+++ b/src/step.ts
@@ -864,7 +864,7 @@ const ShanghaiStep = {
 const isSelectorMLoadCallData = (expr: Expr, memory: Ram<Expr>['memory']) =>
     expr.tag === 'MLoad' &&
     expr.location.isZero() &&
-    memory.get(0x0n) === undefined && (value =>
+    !memory.has(0x0n) && (value =>
         (
             value?.tag === 'CallDataLoad' &&
             value.location.isZero()

--- a/src/step.ts
+++ b/src/step.ts
@@ -677,8 +677,8 @@ const FrontierStep = {
                     if (selectorVal?.isVal() && selectorVal.val % (1n << 224n) === 0n) {
                         selector = (selectorVal.val >> 224n).toString(16).padStart(8, '0');
                     } else {
-                        const selectorVal = memory.get((offset.val) - 28n)?.eval();
-                        if (selectorVal?.isVal() && selectorVal.val <= 0xffffffff) {
+                        const selectorVal = memory.get(offset.val - 28n)?.eval();
+                        if (selectorVal?.isVal() && selectorVal.val <= 0xffffffffn) {
                             selector = selectorVal.val.toString(16).padStart(8, '0');
                         }
                     }

--- a/src/step.ts
+++ b/src/step.ts
@@ -334,7 +334,7 @@ const datacopy = (kind: DataCopy['kind']) => function datacopy({ stack, memory }
     if (!dest.isVal()) {
         // throw new Error('expected number in returndatacopy');
     } else {
-        memory[Number(dest.val)] = new ast.DataCopy(kind, offset, size, address);
+        memory.set(dest.val, new ast.DataCopy(kind, offset, size, address));
     }
     // stmts.push(new MStore(location, data));
 };
@@ -348,14 +348,14 @@ const DATACOPY = {
         if (!dest.isVal() || dest.val >= 1024 * 32) {
             throw new ExecError('Memory destination for CODECOPY is not reducible to Val');
         } else {
-            memory[Number(dest.val)] = new ast.DataCopy('codecopy', offset, size, undefined,
+            memory.set(dest.val, new ast.DataCopy('codecopy', offset, size, undefined,
                 ((offset, size) => {
                     if (offset.isVal() && size.isVal()) {
                         return bytecode.subarray(Number(offset.val), Number(offset.val + size.val));
                     }
                     return undefined;
                 })(offset.eval(), size.eval())
-            );
+            ));
         }
     }],
     EXTCODECOPY: [0x3c, state => {
@@ -499,12 +499,12 @@ class ArgsFetcher {
     readonly args: Expr[] = [];
     constructor(readonly memory: Ram<Expr>['memory']) { }
 
-    fetch(i: number) {
-        this.args.push(this.memory[i]?.eval() ?? new ast.MLoad(new Val(BigInt(i))));
+    fetch(i: bigint) {
+        this.args.push(this.memory.get(i)?.eval() ?? new ast.MLoad(new Val(i)));
     }
 
     range(offset: Val, size: Val) {
-        for (let i = Number(offset.val); i < Number(offset.val + size.val); i += 32) {
+        for (let i = offset.val; i < offset.val + size.val; i += 32n) {
             this.fetch(i);
         }
         return this;
@@ -578,8 +578,8 @@ const FrontierStep = {
     MLOAD: [0x51, ({ stack, memory }: Ram<Expr>) => {
         const location = stack.pop();
         stack.push(new ast.MLoad(location, (location =>
-            location.isVal() && Number(location.val) in memory
-                ? memory[Number(location.val)]
+            location.isVal()
+                ? memory.get(location.val)
                 : undefined
         )(location.eval())));
     }],
@@ -597,7 +597,7 @@ const FrontierStep = {
 
         location = location.eval();
         if (location.isVal()) {
-            memory[Number(location.val)] = data;
+            memory.set(location.val, data);
         }
     }]])),
     MSIZE: [0x59, ({ stack }: Operand<Expr>) => stack.push(new ast.Prop('msize()', 'uint'))],
@@ -610,8 +610,8 @@ const FrontierStep = {
         const offset = stack.pop();
         const size = stack.pop();
         stack.push(new ast.Create(value, offset, size, ((offset, size) => {
-            if (offset.isVal() && size.isVal() && Number(offset.val) in memory) {
-                const data = memory[Number(offset.val)];
+            if (offset.isVal() && size.isVal() && memory.has(offset.val)) {
+                const data = memory.get(offset.val)!;
                 if (data.tag === 'DataCopy' && data.bytecode !== undefined && data.bytecode.length === Number(size.val)) {
                     return data.bytecode;
                 }
@@ -629,7 +629,7 @@ const FrontierStep = {
         const retLen = stack.pop();
         stack.push(new ast.Call(gas, address, value, argsStart, argsLen, retStart, retLen));
         if (retStart.isVal()) {
-            memory[Number(retStart.val)] = new ast.ReturnData(retStart, retLen);
+            memory.set(retStart.val, new ast.ReturnData(retStart, retLen));
         }
     }],
     CALLCODE: [0xf2, function callcode({ stack }) {
@@ -673,18 +673,18 @@ const FrontierStep = {
                 // https://docs.soliditylang.org/en/latest/control-structures.html#revert
                 if (size.val % 32n === 4n) {
                     let selector: string | undefined;
-                    const selectorVal = memory[Number(offset.val)]?.eval();
+                    const selectorVal = memory.get(offset.val)?.eval();
                     if (selectorVal?.isVal() && selectorVal.val % (1n << 224n) === 0n) {
                         selector = (selectorVal.val >> 224n).toString(16).padStart(8, '0');
                     } else {
-                        const selectorVal = memory[Number(offset.val) - 28]?.eval();
+                        const selectorVal = memory.get((offset.val) - 28n)?.eval();
                         if (selectorVal?.isVal() && selectorVal.val <= 0xffffffff) {
                             selector = selectorVal.val.toString(16).padStart(8, '0');
                         }
                     }
 
                     if (selector !== undefined) {
-                        for (let i = Number(offset.val) + 4; i < Number(offset.val + size.val); i += 32) {
+                        for (let i = offset.val + 4n; i < offset.val + size.val; i += 32n) {
                             fetcher.fetch(i);
                         }
                         return [selector, this.getError(selector), fetcher.args];
@@ -731,8 +731,8 @@ const FrontierStep = {
             stmts.push(new ast.Log(event, offset_, size_, topics, function (offset, size) {
                 if (offset.isVal() && size.isVal() && size.val <= MAXSIZE) {
                     const args = [];
-                    for (let i = Number(offset.val); i < Number(offset.val + size.val); i += 32) {
-                        args.push(i in memory ? memory[i] : new ast.MLoad(new Val(BigInt(i))));
+                    for (let i = offset.val; i < offset.val + size.val; i += 32n) {
+                        args.push(memory.get(i) ?? new ast.MLoad(new Val((i))));
                     }
                     return args;
                 } else {
@@ -864,17 +864,17 @@ const ShanghaiStep = {
 const isSelectorMLoadCallData = (expr: Expr, memory: Ram<Expr>['memory']) =>
     expr.tag === 'MLoad' &&
     expr.location.isZero() &&
-    memory[0x0] === undefined && (
+    memory.get(0x0n) === undefined && (value =>
         (
-            memory[0x1c].tag === 'CallDataLoad' &&
-            memory[0x1c].location.isZero()
+            value?.tag === 'CallDataLoad' &&
+            value.location.isZero()
         ) || (
-            memory[0x1c].tag === 'DataCopy' &&
-            memory[0x1c].kind === 'calldatacopy' &&
-            memory[0x1c].offset.isZero() &&
-            memory[0x1c].size.isVal() && memory[0x1c].size.val === 0x4n
+            value?.tag === 'DataCopy' &&
+            value.kind === 'calldatacopy' &&
+            value.offset.isZero() &&
+            value.size.isVal() && value.size.val === 0x4n
         )
-    );
+    )(memory.get(0x1cn));
 
 const VyperFunctionSelector = {
     ISZERO: [ConstantinopleStep.ISZERO[0], ({ stack, memory }: Ram<Expr>) => {

--- a/test/evm.test.ts
+++ b/test/evm.test.ts
@@ -342,7 +342,7 @@ describe('::evm', function () {
                             super.CODECOPY(state, _opcode, evm);
 
                             if (dest?.isVal()) {
-                                const m = state.memory[Number(dest.val)] as DataCopy;
+                                const m = state.memory.get(dest.val) as DataCopy;
                                 tokenBytecode = m.bytecode;
                             }
                         };

--- a/test/exprs.test.ts
+++ b/test/exprs.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import util from 'util';
 
-import { Shanghai, sol, yul, type Ram, State } from 'sevm';
+import { Shanghai, sol, yul, type Ram, State, Memory } from 'sevm';
 import type { Expr } from 'sevm/ast';
 import { Add, Byte, CallDataLoad, CallValue, Div, Eq, Exp, IsZero, MLoad, Mod, Mul, Not, Prop, Props, Sha3, Shl, Sig, Sub, Val } from 'sevm/ast';
 
@@ -10,7 +10,7 @@ const id = <E>(expr: E): E => expr;
 type FilterFn<T, F> = { [k in keyof T]: T[k] extends F ? k : never }[keyof T];
 
 type StackStep = bigint | FilterFn<InstanceType<typeof Shanghai>, (state: Ram<Expr>) => void>;
-const t = <E>(insts: StackStep[], expr: E, val: Expr | ((expr: E) => Expr), solstr: string, yulstr: string, memory: Ram<Expr>['memory'] = {}) => ({
+const t = <E>(insts: StackStep[], expr: E, val: Expr | ((expr: E) => Expr), solstr: string, yulstr: string, memory = Memory.new<Expr>()) => ({
     insts,
     expr,
     val: typeof val === 'function' ? val(expr) : val,
@@ -122,7 +122,7 @@ const $exprs = {
             new MLoad(new Add(new Val(4n), new Val(8n)), Props['block.chainid']),
             Props['block.chainid'],
             'memory[0x4 + 0x8]', 'mload(add(0x4, 0x8))',
-            { 12: Props['block.chainid'] }
+            Memory.new<Expr>().set(12n, Props['block.chainid'])
         ),
         t(['MSIZE'], new Prop('msize()', 'uint'), id, 'msize()', 'msize()'),
     ],
@@ -135,7 +135,7 @@ const $exprs = {
             id,
             'keccak256(msg.value)',
             'keccak256(0x40, 0x20 /*callvalue()*/)',
-            { 0x40: new CallValue() }
+            Memory.new<Expr>().set(0x40n, new CallValue())
         ),
     ],
 };

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -72,17 +72,17 @@ describe('::state', function () {
             const state = new State<number, number>();
             expect(state.halted).to.be.false;
             expect(state.stmts).to.be.empty;
-            expect(state.memory).to.be.empty;
+            expect(state.memory.size).to.be.equal(0);
             expect(state.nlocals).to.be.equal(0);
 
-            state.memory[0] = 1;
+            state.memory.set(0n, 1);
             state.nlocals += 3;
             const clone = state.clone();
 
-            state.memory[1] = 2;
+            state.memory.set(1n, 2);
 
-            expect(state.memory).to.have.keys([0, 1]);
-            expect(clone.memory).to.have.keys([0]);
+            expect([...state.memory.keys()]).to.have.keys([0, 1]);
+            expect([...clone.memory.keys()]).to.have.keys([0]);
             expect(clone.nlocals).to.be.equal(3);
         });
 
@@ -90,18 +90,18 @@ describe('::state', function () {
             const expr = { x: 'a' as 'a' | 'b' };
 
             const state = new State<never, { x: 'a' | 'b' }>();
-            state.memory[0] = expr;
+            state.memory.set(0n, expr);
             const clone = state.clone();
 
-            state.memory[1] = expr;
+            state.memory.set(1n, expr);
             expr.x = 'b';
 
-            expect(state.memory).to.have.keys([0, 1]);
-            expect(state.memory[0]).to.be.deep.equal({ x: 'b' });
-            expect(state.memory[1]).to.be.deep.equal({ x: 'b' });
+            expect([...state.memory.keys()]).to.have.members([0n, 1n]);
+            expect(state.memory.get(0n)).to.be.deep.equal({ x: 'b' });
+            expect(state.memory.get(1n)).to.be.deep.equal({ x: 'b' });
 
-            expect(clone.memory).to.have.keys([0]);
-            expect(state.memory[0]).to.be.deep.equal({ x: 'b' });
+            expect([...clone.memory.keys()]).to.have.keys([0n]);
+            expect(state.memory.get(0n)).to.be.deep.equal({ x: 'b' });
         });
     });
 });

--- a/test/step.test.ts
+++ b/test/step.test.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { Opcode, type Operand, sol, Stack, State, London, Paris, Shanghai, ExecError, splitMetadataHash, yul } from 'sevm';
+import { Opcode, type Operand, sol, Stack, State, London, Paris, Shanghai, ExecError, splitMetadataHash, yul, Memory } from 'sevm';
 import { Val, type Expr, Local, Locali, type Inst, Invalid, MStore, Jump, Branch, Jumpi, Log, type IEvents, Props, DataCopy, Sub, Variable } from 'sevm/ast';
 import { Add, Create, MLoad, Return, SelfDestruct, Stop } from 'sevm/ast';
 import * as ast from 'sevm/ast';
@@ -387,9 +387,9 @@ describe('::step', function () {
             state.stack.push(new Val(4n));
             step.CODECOPY(state, new Opcode(0, 0, 'codecopy'), { bytecode });
 
-            expect(state.memory).to.be.deep.equal({
-                '4': new DataCopy('codecopy', offset, size, undefined, bytecode.subarray(2, 5))
-            });
+            expect(state.memory).to.be.deep.equal(Memory.new()
+                .set(4n, new DataCopy('codecopy', offset, size, undefined, bytecode.subarray(2, 5)))
+            );
             expect(state.stack.values).to.be.deep.equal([]);
         });
     });
@@ -404,7 +404,7 @@ describe('::step', function () {
             state.stack.push(new Val(4n));
             step.MSTORE(state);
 
-            expect(state.memory).to.be.deep.equal({ '4': Props['block.coinbase'] });
+            expect(state.memory).to.be.deep.equal(Memory.new().set(4n, Props['block.coinbase']));
             expect(state.stmts).to.be.deep.equal([new MStore(new Val(4n), Props['block.coinbase'])]);
         });
     });
@@ -443,7 +443,7 @@ describe('::step', function () {
             state.stack.push(new Val(0x10n));
             state.stack.push(new Val(0x1000n));
 
-            state.memory[0x10] = new DataCopy('codecopy', new Val(1n), new Val(2n), undefined, bytecode);
+            state.memory.set(0x10n, new DataCopy('codecopy', new Val(1n), new Val(2n), undefined, bytecode));
 
             step.CREATE(state);
             expect(state.stack.values).to.be.deep.equal([


### PR DESCRIPTION
Context memory is represented with a plain object. Plain objects only allows keys to be either `string` or `Symbol`. This can pose problems where memory locations are realized as `bigint`s, needing to convert to a `number` to query for memory locations.

This PR introduces a `Memory` class to support context memory using `bigint` directly. Moreover, by having a unique access point for memory locations, it can be easier to invalidate certain or all locations in a given `Memory`.