### PR TITLE
Enable dataset workflow on PRs

### DIFF
--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -37,4 +37,4 @@ jobs:
         if: github.event_name == 'pull_request'
         with:
           recreate: true
-          path: dist/dataset-summary.txt
+          message: ${{ env.GITHUB_STEP_SUMMARY }}

--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -25,16 +25,18 @@ jobs:
       - run: yarn test --grep ::dataset
         env:
           ENABLE_DATASET_TEST: 1
-      - name: Include dataset summary
+      - name: Format dataset summary to Markdown
         run: |
-          echo "## Contract Dataset Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`txt" >> $GITHUB_STEP_SUMMARY
-          cat dist/dataset-summary.txt >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "## Contract Dataset Summary" >> dist/dataset-summary.md
+          echo "" >> dist/dataset-summary.md
+          echo "\`\`\`txt" >> dist/dataset-summary.md
+          cat dist/dataset-summary.txt >> dist/dataset-summary.md
+          echo "\`\`\`" >> dist/dataset-summary.md
+      - name: Include dataset summary
+        run: cat dist/dataset-summary.md >> $GITHUB_STEP_SUMMARY
       - name: Add dataset summary PR comment
         uses: marocchino/sticky-pull-request-comment@v2
         if: github.event_name == 'pull_request'
         with:
           recreate: true
-          message: ${{ env.GITHUB_STEP_SUMMARY }}
+          path: dist/dataset-summary.md

--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -1,6 +1,10 @@
 name: Contract Dataset Test
 
-on: workflow_dispatch
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 env:
   FORCE_COLOR: 3
@@ -28,3 +32,9 @@ jobs:
           echo "\`\`\`txt" >> $GITHUB_STEP_SUMMARY
           cat dist/dataset-summary.txt >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+      - name: Add dataset summary PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          recreate: true
+          path: dist/dataset-summary.txt


### PR DESCRIPTION
This PR enables running the `Contract Dataset Test` workflow on PRs in addition to `workflow_dispatch` trigger.

Given the workflow summary gives a nice overview of the run, this PR also enables commenting subsequent PRs with the workflow summary in Markdown format.

The summary structure was also changed to display contract errors by `reason` instead of by contracts. This makes the summary more compact and concise. Also it is more important to see what kind of errors we have rather than a list of contracts. In addition, the other stats were also compacted to avoid spanning many lines.
