### PR TITLE
Include Dataset Coverage report and improve report summary

### DIFF
--- a/.github/workflows/dataset.yml
+++ b/.github/workflows/dataset.yml
@@ -9,6 +9,11 @@ on:
 env:
   FORCE_COLOR: 3
 
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dataset-test:
     runs-on: ubuntu-latest

--- a/test/dataset.test.ts
+++ b/test/dataset.test.ts
@@ -275,7 +275,7 @@ describe(`::dataset | MAX=\`${MAX ?? ''}\` BAIL=\`${BAIL ?? ''}\`${hint}`, funct
             const write = (text: string) => summary += text + '\n';
 
             const showErr = (count: number) => `${count === 1 ? '' : warn(`(x${count})`)}`;
-            write(heading(`Symbolic Execution Errors - ${emph(`${errorsByReasonCount} errors of ${errorsByReason.size} kinds`)} (in ${emph(`${errorsByContract.size}`)} contracts)`));
+            write(heading(`\u{26A0}\u{FE0F} Symbolic Execution Errors - ${emph(`${errorsByReasonCount} errors of ${errorsByReason.size} kinds`)} (in ${emph(`${errorsByContract.size}`)} contracts)`));
             for (const [reason, addresses] of errorsByReason.entries()) {
                 write(`    ${error('x')} ${reason} - ${warn(`${addresses.total} error(s)`)}`);
                 const addrs = [...addresses];
@@ -287,7 +287,7 @@ describe(`::dataset | MAX=\`${MAX ?? ''}\` BAIL=\`${BAIL ?? ''}\`${hint}`, funct
                     write(c.dim(`    ... ${addrs.length - displayCount} more contracts`));
             }
 
-            write(heading('Bench Stats'));
+            write(heading('\u{26A1} Bench Stats'));
             for (const bench of [execStats, solStats, yulStats]) {
                 let out = '';
                 out += `${'average'} ${emph(`${(bench.average / 1_000_000).toFixed(1)} ms`)}`;
@@ -296,12 +296,12 @@ describe(`::dataset | MAX=\`${MAX ?? ''}\` BAIL=\`${BAIL ?? ''}\`${hint}`, funct
             }
 
             const cc = (def: string) => ([k, v]: [string, number]) => `${code(k !== '' ? k : def)}${emph(`(${v})`)}`;
-            write(heading('Metadata Stats'));
+            write(heading('\u{1F3F7} \u{FE0F} Metadata Stats'));
             write(item(`${info('No metadata')} ${emph(`(${metadataStats.noMetadata})`)}`));
             write(item(`${info('Protocols')} ${[...metadataStats.protocols.sorted()].map(cc('<no protocol>')).join(' ')}`));
             write(item(`${info('SOLC versions')} ${[...metadataStats.solcs.sorted()].map(cc('<no version>')).join(' ')}`));
 
-            write(heading('Bytecode Stats'));
+            write(heading('\u{1F4DC} Bytecode Stats'));
             write(item(`${info('Selectors')} Missed selectors ${emph(`(${selectorStats.missedSelectors.size})`)} | Hit selectors ${emph(`(${selectorStats.hitSelectors.size})`)} `));
             write(item(`${info('ERCs')} ${emph(`(most used first)`)} ` + ercsStats.counts.sorted().map(([erc, count]) => `${code(erc)}${emph(`(${count})`)}`).join(' | ')));
             write(item(`${info('Precompiled Contracts')} ${emph(`(most used first)`)} ` + hookStats.precompiles.sorted().map(([address, count]) => `${code(address)}${emph(`(${count})`)}`).join(' | ')));

--- a/test/dataset.test.ts
+++ b/test/dataset.test.ts
@@ -306,7 +306,7 @@ describe(`::dataset | MAX=\`${MAX ?? ''}\` BAIL=\`${BAIL ?? ''}\`${hint}`, funct
             write(item(`ERCs ${emph(`(most used first)`)} ` + ercsStats.counts.sorted().map(([erc, count]) => `${code(erc)}${emph(`(${count})`)}`).join(' | ')));
             write(item(`Precompiled Contracts ${emph(`(most used first)`)} ` + hookStats.precompiles.sorted().map(([address, count]) => `${code(address)}${emph(`(${count})`)}`).join(' | ')));
             write(item(`${code('PC')}s ${emph(`(${hookStats.pcs})`)}`));
-            write(item(`Coverage \u{1F6A7} ${coverageStats.unreachableJumpDestChunks}/${coverageStats.nchunks} unreacheable chunks ${emph(`(${(coverageStats.unreachableJumpDestSize / 1024).toFixed(1)}k)`)}`));
+            write(item(`Coverage \u{1F6A7} ${fmt(coverageStats.unreachableJumpDestChunks)}/${fmt(coverageStats.nchunks)} unreacheable chunks ${emph(`(${(coverageStats.unreachableJumpDestSize / 1024).toFixed(1)}k)`)}`));
 
             write(heading('Revert Selector Stats ' + emph(`(most used first)`)));
             const revertSelectors = hookStats.revertSelectors.sorted();
@@ -372,7 +372,11 @@ function coverage(contract: Contract, ctx: Mocha.Context): {
 
     expect(nopcodes).to.be.equal(contract.opcodes().length);
     if (unreachableJumpDestChunks > 0)
-        ctx.test!.title += ` \u{1F6A7}${unreachableJumpDestChunks}/${chunks.length} (${unreachableJumpDestSize}b)`;
+        ctx.test!.title += ` \u{1F6A7}${fmt(unreachableJumpDestChunks)}/${fmt(chunks.length)} (${unreachableJumpDestSize}b)`;
 
     return { unreachableJumpDestChunks, unreachableJumpDestSize, nchunks: chunks.length };
+}
+
+function fmt(value: number) {
+    return new Intl.NumberFormat("en-US").format(value);
 }

--- a/test/dataset.test.ts
+++ b/test/dataset.test.ts
@@ -308,10 +308,9 @@ describe(`::dataset | MAX=\`${MAX ?? ''}\` BAIL=\`${BAIL ?? ''}\`${hint}`, funct
             write(item(`${code('PC')}s ${emph(`(${hookStats.pcs})`)}`));
             write(item(`${info('Coverage')} \u{1F6A7} ${fmt(coverageStats.unreachableJumpDestChunks)}/${fmt(coverageStats.nchunks)} unreacheable chunks ${emph(`(${(coverageStats.unreachableJumpDestSize / 1024).toFixed(1)}k)`)}`));
 
-            write(heading('Revert Selector Stats ' + emph(`(most used first)`)));
             const revertSelectors = hookStats.revertSelectors.sorted();
             const displayCount = 15;
-            write(item(revertSelectors.slice(0, displayCount).map(([selector, count]) => `${code(selector)}${emph(`(${count})`)}`).join(' | ')));
+            write(item(`${info('Revert Selectors')} ${emph(`(most used first)`)} ` + revertSelectors.slice(0, displayCount).map(([selector, count]) => `${code(selector)}${emph(`(${count})`)}`).join(' | ')));
             if (revertSelectors.length > displayCount)
                 write('    ' + emph(`...${revertSelectors.length - displayCount} more revert selectors`));
 

--- a/test/dataset.test.ts
+++ b/test/dataset.test.ts
@@ -302,11 +302,11 @@ describe(`::dataset | MAX=\`${MAX ?? ''}\` BAIL=\`${BAIL ?? ''}\`${hint}`, funct
             write(item(`${info('SOLC versions')} ${[...metadataStats.solcs.sorted()].map(cc('<no version>')).join(' ')}`));
 
             write(heading('Bytecode Stats'));
-            write(item('Selectors ' + `${info('Missed selectors')} ${emph(`(${selectorStats.missedSelectors.size})`)} | ${info('Hit selectors')} ${emph(`(${selectorStats.hitSelectors.size})`)} `));
-            write(item(`ERCs ${emph(`(most used first)`)} ` + ercsStats.counts.sorted().map(([erc, count]) => `${code(erc)}${emph(`(${count})`)}`).join(' | ')));
-            write(item(`Precompiled Contracts ${emph(`(most used first)`)} ` + hookStats.precompiles.sorted().map(([address, count]) => `${code(address)}${emph(`(${count})`)}`).join(' | ')));
+            write(item(`${info('Selectors')} Missed selectors ${emph(`(${selectorStats.missedSelectors.size})`)} | Hit selectors ${emph(`(${selectorStats.hitSelectors.size})`)} `));
+            write(item(`${info('ERCs')} ${emph(`(most used first)`)} ` + ercsStats.counts.sorted().map(([erc, count]) => `${code(erc)}${emph(`(${count})`)}`).join(' | ')));
+            write(item(`${info('Precompiled Contracts')} ${emph(`(most used first)`)} ` + hookStats.precompiles.sorted().map(([address, count]) => `${code(address)}${emph(`(${count})`)}`).join(' | ')));
             write(item(`${code('PC')}s ${emph(`(${hookStats.pcs})`)}`));
-            write(item(`Coverage \u{1F6A7} ${fmt(coverageStats.unreachableJumpDestChunks)}/${fmt(coverageStats.nchunks)} unreacheable chunks ${emph(`(${(coverageStats.unreachableJumpDestSize / 1024).toFixed(1)}k)`)}`));
+            write(item(`${info('Coverage')} \u{1F6A7} ${fmt(coverageStats.unreachableJumpDestChunks)}/${fmt(coverageStats.nchunks)} unreacheable chunks ${emph(`(${(coverageStats.unreachableJumpDestSize / 1024).toFixed(1)}k)`)}`));
 
             write(heading('Revert Selector Stats ' + emph(`(most used first)`)));
             const revertSelectors = hookStats.revertSelectors.sorted();

--- a/test/dataset.test.ts
+++ b/test/dataset.test.ts
@@ -354,18 +354,18 @@ function coverage(contract: Contract, ctx: Mocha.Context): {
     const chunks = contract.chunks();
     for (const chunk of chunks) {
         if (chunk.content instanceof Uint8Array) {
-            expect(chunk.states === undefined);
-            expect(chunk.content.length > 0);
+            expect(chunk.states).to.be.undefined;
+            expect(chunk.content.length).to.be.above(0);
             if (chunk.content[0] === JUMPDEST) {
                 unreachableJumpDestChunks++;
                 unreachableJumpDestSize += chunk.content.length;
             }
         } else {
             const block = contract.blocks.get(chunk.pcbegin);
-            expect(chunk.states !== undefined);
-            expect(block !== undefined);
-            expect(block!.opcodes.length === chunk.content.length);
-            expect(chunk.content.length > 0);
+            expect(chunk.states).to.not.be.undefined;
+            expect(block).to.not.be.undefined;
+            expect(block!.opcodes.length).to.be.equal(chunk.content.length);
+            expect(chunk.content.length).to.be.above(0);
             nopcodes += chunk.content.length;
         }
     }


### PR DESCRIPTION
This PR includes Dataset Coverage report in the summary and for each contract. For example, the summary now looks like

```md
- Coverage 🚧 165,312/1,991,703 unreacheable chunks (16809.2k)
```

On the other hand, in case there are some unreachable chunks in a test contract, it now appends coverage info at the end using the 🚧 icon, for example

```
    ✔ Invest 0xB8065a3F28F40FEfFEeBDA829fcC8A5628328496 ~14.2k ERC:20|20Metadata {}✓ 🚧16/401 (1261b)
```

this can be read as _there are 16 unreachable chunks out of 401 blocks, totalling `1261b` (bytes) of unreachable bytecode_.

Moreover, all bytecode related stats are now group in their own section _Bytecode Stats_.

In addition, this PR also cancels previous runs of the Dataset workflow on newly pushed commits. This is to avoid excessive resource usage when commits are pushed in a short period of time.